### PR TITLE
Feature: Adding Mastodon parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "obsidian-sample-plugin",
-  "version": "0.0.16",
+  "name": "obsidian-ReadItLater",
+  "version": "0.0.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "obsidian-sample-plugin",
-      "version": "0.0.16",
+      "name": "obsidian-ReadItLater",
+      "version": "0.0.17",
       "license": "MIT",
       "dependencies": {
         "@guyplusplus/turndown-plugin-gfm": "^1.0.7",

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import BilibiliParser from './parsers/BilibiliParser';
 import TwitterParser from './parsers/TwitterParser';
 import WebsiteParser from './parsers/WebsiteParser';
 import TextSnippetParser from './parsers/TextSnippetParser';
+import MastodonParser from './parsers/MastodonParser';
 
 export default class ReadItLaterPlugin extends Plugin {
     settings: ReadItLaterSettings;
@@ -20,6 +21,7 @@ export default class ReadItLaterPlugin extends Plugin {
             new YoutubeParser(this.app, this.settings),
             new BilibiliParser(this.app, this.settings),
             new TwitterParser(this.app, this.settings),
+            new MastodonParser(this.app, this.settings),
             new WebsiteParser(this.app, this.settings),
             new TextSnippetParser(this.app, this.settings),
         ];
@@ -53,7 +55,7 @@ export default class ReadItLaterPlugin extends Plugin {
         const clipboardContent = await navigator.clipboard.readText();
 
         for (const parser of this.parsers) {
-            if (parser.test(clipboardContent)) {
+            if (await parser.test(clipboardContent)) {
                 const note = await parser.prepareNote(clipboardContent);
                 await this.writeFile(note.fileName, note.content);
                 break;

--- a/src/parsers/MastodonParser.ts
+++ b/src/parsers/MastodonParser.ts
@@ -67,15 +67,20 @@ class MastodonParser extends Parser {
         if (!url) return false;
 
         const urlDomain = new URL(url).hostname;
-        const response = JSON.parse(
-            await request({
-                method: 'GET',
-                contentType: 'application/json',
-                url: `https://${urlDomain}${MASTODON_API.INSTANCE}`,
-            }),
-        );
 
-        return response?.domain === urlDomain;
+        try {
+            const response = JSON.parse(
+                await request({
+                    method: 'GET',
+                    contentType: 'application/json',
+                    url: `https://${urlDomain}${MASTODON_API.INSTANCE}`,
+                }),
+            );
+
+            return response?.domain === urlDomain;
+        } catch (e) {
+            return false;
+        }
     }
 }
 

--- a/src/parsers/MastodonParser.ts
+++ b/src/parsers/MastodonParser.ts
@@ -1,0 +1,82 @@
+import { Parser } from './Parser';
+import { ReadItLaterSettings } from '../settings';
+import { App, request } from 'obsidian';
+import { Note } from './Note';
+import { isValidUrl } from '../helpers';
+import { parseHtmlContent } from './parsehtml';
+
+const MASTODON_API = {
+    INSTANCE: '/api/v2/instance',
+    OEMBED: '/api/oembed',
+    STATUS: '/api/v1/statuses',
+};
+
+class MastodonParser extends Parser {
+    constructor(app: App, settings: ReadItLaterSettings) {
+        super(app, settings);
+    }
+
+    async test(url: string): Promise<boolean> {
+        return isValidUrl(url) && (await this.testIsMastodon(url));
+    }
+
+    async prepareNote(url: string): Promise<Note> {
+        const mastodonUrl = new URL(url);
+        const tootId = mastodonUrl.pathname.split('/')[2];
+
+        const response = JSON.parse(
+            await request({
+                method: 'GET',
+                contentType: 'application/json',
+                url: `https://${mastodonUrl.hostname}${MASTODON_API.STATUS}/${tootId}`,
+            }),
+        );
+
+        const { url: tootURL, content, account, media_attachments } = response;
+
+        const processedContent = this.settings.mastodonNote
+            .replace(/%date%/g, this.getFormattedDateForContent())
+            .replace(/%tootAuthorName%/g, account.display_name)
+            .replace(/%tootURL%/g, tootURL)
+            .replace(/%tootContent%/g, await parseHtmlContent(content))
+            .replace(/%tootMedia%/g, this.prepareMedia(media_attachments));
+
+        const fileNameTemplate = this.settings.mastodonNoteTitle
+            .replace(/%tootAuthorName%/g, account.display_name)
+            .replace(/%date%/g, this.getFormattedDateForFilename());
+
+        const fileName = `${fileNameTemplate}.md`;
+
+        return new Note(fileName, processedContent);
+    }
+
+    private prepareMedia(media: any[]): string {
+        return media.reduce(
+            (prev: string, { type, url, description }: { type: string; url: string; description: string }): string => {
+                if (type !== 'image') return prev;
+
+                const processedDescription = description ? `> <em>${description}</em>` : '';
+
+                return `${prev}\n![](${url})\n ${processedDescription}\n`;
+            },
+            '',
+        );
+    }
+
+    private async testIsMastodon(url: string): Promise<boolean> {
+        if (!url) return false;
+
+        const urlDomain = new URL(url).hostname;
+        const response = JSON.parse(
+            await request({
+                method: 'GET',
+                contentType: 'application/json',
+                url: `https://${urlDomain}${MASTODON_API.INSTANCE}`,
+            }),
+        );
+
+        return response?.domain === urlDomain;
+    }
+}
+
+export default MastodonParser;

--- a/src/parsers/Parser.ts
+++ b/src/parsers/Parser.ts
@@ -11,7 +11,7 @@ export abstract class Parser {
         this.settings = settings;
     }
 
-    abstract test(clipboardContent: string): boolean;
+    abstract test(clipboardContent: string): boolean | Promise<boolean>;
 
     abstract prepareNote(clipboardContent: string): Promise<Note>;
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -14,6 +14,8 @@ export interface ReadItLaterSettings {
     notParsableArticleNote: string;
     textSnippetNoteTitle: string;
     textSnippetNote: string;
+    mastodonNoteTitle: string;
+    mastodonNote: string;
     downloadImages: boolean;
     downloadImagesInArticleDir: boolean;
     dateTitleFmt: string;
@@ -36,6 +38,8 @@ export const DEFAULT_SETTINGS: ReadItLaterSettings = {
     notParsableArticleNote: `[[ReadItLater]] [[Article]]\n\n[%articleURL%](%articleURL%)`,
     textSnippetNoteTitle: 'Note %date%',
     textSnippetNote: `[[ReadItLater]] [[Textsnippet]]\n\n%content%`,
+    mastodonNoteTitle: 'Toot from %tootAuthorName% (%date%)',
+    mastodonNote: `[[ReadItLater]] [[Toot]]\n\n# [%tootAuthorName%](%tootURL%)\n\n> %tootContent%\n\n%tootMedia%`,
     downloadImages: true,
     downloadImagesInArticleDir: false,
     dateTitleFmt: 'YYYY-MM-DD HH-mm-ss',

--- a/src/views/settings-tab.ts
+++ b/src/views/settings-tab.ts
@@ -60,12 +60,12 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
 
         const imagesInArticleDirSettings = new Setting(containerEl)
             .setName('Download images to article folder')
-            .setDesc(
-                'If enabled, the images of an article are stored in their own folder.',
-            )
+            .setDesc('If enabled, the images of an article are stored in their own folder.')
             .addToggle((toggle) =>
                 toggle
-                    .setValue(this.plugin.settings.downloadImagesInArticleDir || DEFAULT_SETTINGS.downloadImagesInArticleDir)
+                    .setValue(
+                        this.plugin.settings.downloadImagesInArticleDir || DEFAULT_SETTINGS.downloadImagesInArticleDir,
+                    )
                     .onChange(async (value) => {
                         this.plugin.settings.downloadImagesInArticleDir = value;
                         await this.plugin.saveSettings();
@@ -195,6 +195,32 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
             });
 
         new Setting(containerEl)
+            .setName('Mastodon note template title')
+            .setDesc('Available variables: %tootAuthorName%, %date%')
+            .addText((text) =>
+                text
+                    .setPlaceholder('Defaults to %tootAuthorName%')
+                    .setValue(this.plugin.settings.mastodonNoteTitle || DEFAULT_SETTINGS.mastodonNoteTitle)
+                    .onChange(async (value) => {
+                        this.plugin.settings.mastodonNoteTitle = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+        new Setting(containerEl)
+            .setName('Mastodon note template')
+            .setDesc('Available variables: %date%, %tootAuthorName%, %tootURL%, %tootContent%, %tootMedia%')
+            .addTextArea((textarea) => {
+                textarea
+                    .setValue(this.plugin.settings.mastodonNote || DEFAULT_SETTINGS.mastodonNote)
+                    .onChange(async (value) => {
+                        this.plugin.settings.mastodonNote = value;
+                        await this.plugin.saveSettings();
+                    });
+                textarea.inputEl.rows = 10;
+                textarea.inputEl.cols = 25;
+            });
+
+        new Setting(containerEl)
             .setName('Parsable article note template title')
             .setDesc('Available variables: %title%, %date%')
             .addText((text) =>
@@ -231,7 +257,7 @@ export class ReadItLaterSettingsTab extends PluginSettingTab {
                     .setPlaceholder(`Defaults to 'Article %date%'`)
                     .setValue(
                         this.plugin.settings.notParseableArticleNoteTitle ||
-                        DEFAULT_SETTINGS.notParseableArticleNoteTitle,
+                            DEFAULT_SETTINGS.notParseableArticleNoteTitle,
                     )
                     .onChange(async (value) => {
                         this.plugin.settings.notParseableArticleNoteTitle = value;


### PR DESCRIPTION
Adds the ability to save Mastodon Posts (aka Toots) to Obsidian.

Includes the following changes:
- Adds a new parser, `MastodonParser` for handling Mastodon URLs
- `test/1` of the `Parser` abstract class can now return a Boolean `Promise`

Notes on testing for Mastodon URLs:
> To determine a URL is a Mastodon instance, the parser will make a `GET` request to the URL's `/api/v2/instance` resource. If the resource responds with an object containing a `domain` property that matches the copied URL hostname, the parser will assume the URL is for a Mastodon instance.
> This step will occur during the "test" phase of saving a link. For this reason, the `test/1` method of the `Parser` abstract needed to allow for the returning of `Promises`.