### PR TITLE
Can now save non-parsable webpags

### DIFF
--- a/src/parsers/WebsiteParser.ts
+++ b/src/parsers/WebsiteParser.ts
@@ -84,10 +84,11 @@ class WebsiteParser extends Parser {
 
         const content = this.settings.notParsableArticleNote.replace('%articleURL%', url);
 
-        const fileNameTemplate = this.settings.notParsableArticleNote.replace(
+        const fileNameTemplate = this.settings.notParseableArticleNoteTitle.replace(
             /%date%/g,
             this.getFormattedDateForFilename(),
         );
+
         const fileName = `${fileNameTemplate}.md`;
         return new Note(fileName, content);
     }


### PR DESCRIPTION
Fixing error that was preventing non-parsable webpages from being saved.